### PR TITLE
Add Search model and prevent crawl twice for tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'devise-jwt', '~> 0.5.9'
 gem 'dry-configurable', '0.9.0' # NOTE: https://github.com/waiting-for-dev/devise-jwt/issues/159
 # Blueprinter is a JSON Object Presenter for Ruby
 gem 'blueprinter'
-
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 

--- a/app/controllers/api/quotes_controller.rb
+++ b/app/controllers/api/quotes_controller.rb
@@ -11,6 +11,9 @@ class Api::QuotesController < ApplicationController
   private
 
   def read_quotes
+    return if Search.where(tag: params[:tag]).exists?
+
     QuotesToScrapReader.call(params[:tag])
+    Search.create(tag: params[:tag], searched_at: Time.zone.now)
   end
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,0 +1,10 @@
+class Search
+  include Mongoid::Document
+
+  field :tag,         type: String, default: ''
+  field :searched_at, type: DateTime
+
+  index({ tag: 1 }, { unique: true })
+
+  validates :tag, presence: true, uniqueness: true
+end

--- a/app/services/quotes_to_scrap_reader.rb
+++ b/app/services/quotes_to_scrap_reader.rb
@@ -1,5 +1,5 @@
 require 'nokogiri'
-require 'open-uri'
+require 'net/http'
 
 class QuotesToScrapReader < ApplicationService
   def initialize(tag)
@@ -7,7 +7,8 @@ class QuotesToScrapReader < ApplicationService
   end
 
   def call
-    doc = Nokogiri::HTML(open(Const::QUOTES_WEBSITE))
+    uri = URI(Const::QUOTES_WEBSITE)
+    doc = Nokogiri::HTML(Net::HTTP.get(uri))
 
     # Prefer use `where().pluck()` (1 + N queries)
     # instead `find_or_create_by` (N * 2 queries)

--- a/test/models/search_test.rb
+++ b/test/models/search_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class SearchTest < ActiveSupport::TestCase
+  test 'should have tag' do
+    search = Search.new
+    search.valid?
+
+    assert_includes search.errors[:tag], "can't be blank"
+  end
+end

--- a/test/services/quotes_to_scrap_reader_test.rb
+++ b/test/services/quotes_to_scrap_reader_test.rb
@@ -20,14 +20,14 @@ class QuotesToScrapReaderTest < ActiveSupport::TestCase
       assert_equal 'Quote one', first.quote
       assert_equal 'Quote One Author', first.author
       assert_equal '/author/Quote-One-Author', first.author_about
-      assert_equal ['quote-1', 'quote-odd'], first.tags
+      assert_equal %w[quote-1 quote-odd], first.tags
 
       second = Quote.last
 
       assert_equal 'Quote three', second.quote
       assert_equal 'Quote Three Author', second.author
       assert_equal '/author/Quote-Three-Author', second.author_about
-      assert_equal ['quote-3', 'quote-odd'], second.tags
+      assert_equal %w[quote-3 quote-odd], second.tags
     end
   end
 end


### PR DESCRIPTION
- Add Search model
- Replace open-uri to not/http (Security cop)
- Rev: Lint the code
- Tests